### PR TITLE
fix: Catch SocketExceptions and log them

### DIFF
--- a/lib/matomo.dart
+++ b/lib/matomo.dart
@@ -367,7 +367,10 @@ class _MatomoDispatcher {
       url = '$url$key=$value&';
     }
     event.tracker.log.fine(' -> $url');
-    http.post(url, headers: headers).then((http.Response response) {
+    http
+        .post(url, headers: headers)
+        .catchError((e) => event.tracker.log.fine(' <- ${e.toString()}'))
+        .then((http.Response response) {
       final int statusCode = response.statusCode;
       event.tracker.log.fine(' <- $statusCode');
       if (statusCode != 200) {}


### PR DESCRIPTION
Hey again :-)
in our Sentry logs we see SocketExceptions from time to time. It seems like that sometimes our app can speak to sentry, but not to our Matomo. I've thought about how to catch this exceptions. What do you think about if we just catch errors from the http request and pipe them to the MatomoLogger?

Best regards and stay healthy