### PR TITLE
fix: refused to set unsafe user agent in web

### DIFF
--- a/lib/matomo.dart
+++ b/lib/matomo.dart
@@ -361,7 +361,7 @@ class _MatomoDispatcher {
 
   void send(_Event event) {
     var headers = {
-      'User-Agent': event.tracker.userAgent,
+      if (!kIsWeb) 'User-Agent': event.tracker.userAgent,
     };
 
     var map = event.toMap();


### PR DESCRIPTION
Hello again :-) how are you?

On web I have found another minor issue because in some browsers we cant set the user agent. So I have placed this condition to fix this. I hope you like the changes.

Have a nice day and stay healthy