### PR TITLE
fix: FlutterUserAgent on desktop

### DIFF
--- a/lib/matomo.dart
+++ b/lib/matomo.dart
@@ -106,9 +106,11 @@ class MatomoTracker {
     // User agent
     if (kIsWeb) {
       userAgent = html.window.navigator.userAgent;
-    } else {
+    } else if (Platform.isAndroid || Platform.isIOS) {
       await FlutterUserAgent.init();
       userAgent = FlutterUserAgent.webViewUserAgent;
+    } else {
+      userAgent = 'Unknown';
     }
 
     // Screen Resolution


### PR DESCRIPTION
Hey, how are you?

We are now trying out the Flutter desktop builds and got this exception:
```
MissingPluginException

MissingPluginException(No implementation found for method getProperties on channel flutter_user_agent)
```

So this Pull Request should fix it and make dart matomo ready for Flutter Desktop :-) I hope you like it.

Best regards and stay healthy