### PR TITLE
Add an optional parameter to configure the interval of dequeuing the events

### DIFF
--- a/lib/matomo.dart
+++ b/lib/matomo.dart
@@ -108,6 +108,7 @@ class MatomoTracker {
     required String url,
     String? visitorId,
     String? contentBaseUrl,
+    int dequeueInterval = 10
   }) async {
     this.siteId = siteId;
     this.url = url;
@@ -189,7 +190,7 @@ class MatomoTracker {
         'Matomo Initialized: firstVisit=$firstVisit; lastVisit=$lastVisit; visitCount=$visitCount; visitorId=$visitorId; contentBase=$contentBase; resolution=${width}x$height; userAgent=$userAgent');
     this.initialized = true;
 
-    _timer = Timer.periodic(Duration(seconds: 10), (timer) {
+    _timer = Timer.periodic(Duration(seconds: dequeueInterval), (timer) {
       this._dequeue();
     });
   }


### PR DESCRIPTION
The default value of dequeuing the events (10 seconds) is adding a lot of stress to a Matomo instance, specially for apps with tens of thousands of users.

I have added an optional parameter to configure this value.

This is a minor change since the consumers won't be forced to change anything unless they want to configure this value.