### PR TITLE
Update track event to follow api requirements

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,7 +36,7 @@ class MyApp extends StatelessWidget {
 class Foundation {}
 
 class MyHomePage extends TraceableStatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key, name: title);
+  MyHomePage({required this.title, super.key});
 
   final String title;
 
@@ -48,7 +48,7 @@ class _MyHomePageState extends State<MyHomePage> {
   int _counter = 0;
 
   void _incrementCounter() {
-    MatomoTracker.trackEvent('IncrementCounter', 'Click');
+    // MatomoTracker.trackEvent('IncrementCounter', 'Click');
     setState(() {
       _counter++;
     });

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/lib/matomo.dart
+++ b/lib/matomo.dart
@@ -251,14 +251,14 @@ class MatomoTracker {
     ));
   }
 
-  static void trackEvent(String eventName, String eventAction,
-      {String? widgetName, int? eventValue}) {
+  static void trackEvent({required String category, 
+  required String action, String? name, num? eventValue}) {
     var tracker = MatomoTracker();
     tracker._track(_Event(
       tracker: tracker,
-      eventAction: eventAction,
-      eventName: eventName,
-      eventCategory: widgetName,
+      eventAction: action,
+      eventName: name,
+      eventCategory: category,
       eventValue: eventValue,
     ));
   }
@@ -362,7 +362,7 @@ class _Event {
   final String? eventCategory;
   final String? eventAction;
   final String? eventName;
-  final int? eventValue;
+  final num? eventValue;
   final int? goalId;
 
   // Ecommerce

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: matomo
 description: Cross-platform Matomo tracking for Flutter, using the Matomo API and written in pure Dart.
-version: 1.1.0
+version: 2.0.0
 homepage: https://github.com/poitch/dart-matomo
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: matomo
 description: Cross-platform Matomo tracking for Flutter, using the Matomo API and written in pure Dart.
-version: 2.0.0
+version: 3.0.0
 homepage: https://github.com/poitch/dart-matomo
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
   fk_user_agent: ^2.1.0
-  http: ^0.13.6
+  http: ^1.0.0
   uuid: ^3.0.3
   package_info_plus: ^4.0.1
   shared_preferences: ^2.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   fk_user_agent: ^2.0.1
   http: ^0.13.1
   uuid: ^3.0.3
-  package_info_plus: ^1.0.4
+  package_info_plus: ^3.0.1
   shared_preferences: ^2.0.5
   logging: ^1.0.1
   universal_html: ^2.0.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,17 +5,16 @@ homepage: https://github.com/poitch/dart-matomo
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.17.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  fk_user_agent: ^2.0.1
-  http: ^0.13.1
+  fk_user_agent: ^2.1.0
+  http: ^0.13.6
   uuid: ^3.0.3
-  package_info_plus: ^3.0.1
+  package_info_plus: ^4.0.1
   shared_preferences: ^2.0.5
-  logging: ^1.0.1
+  logging: ^1.2.0
   universal_html: ^2.0.7
 
 dev_dependencies:


### PR DESCRIPTION
Event category is required, name is optional, value can be num instead of int.

The current implementation has a widgetName parameter that is "optional", That is tied to the category value, which it is actually required by the matomo api otherwise event tracking does not work properly, see [the documentation](https://matomo.org/docs/event-tracking/#the-anatomy-of-an-event).

This change is API breaking.